### PR TITLE
Integrate dotenv

### DIFF
--- a/brunch-server.js
+++ b/brunch-server.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 const express = require('express');
 const cors = require('cors');
 const path = require('path');

--- a/package-lock.json
+++ b/package-lock.json
@@ -5280,6 +5280,11 @@
         "webidl-conversions": "4.0.2"
       }
     },
+    "dotenv": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
+      "integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg=="
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "datatables.net-buttons": "git+https://git@github.com/rw251/Dist-DataTables-Buttons.git",
     "datatables.net-buttons-bs": "git+https://git@github.com/rw251/Dist-DataTables-Buttons-Bootstrap.git",
     "debug": "^2.2.0",
+    "dotenv": "^6.0.0",
     "express": "^4.14.0",
     "express-session": "^1.14.1",
     "file-saver": "^1.3.3",


### PR DESCRIPTION
First go at a pull request!

I've integrated the dotenv package (https://github.com/motdotla/dotenv) to allow environment variables stored in a local .env file to be used

The change is very simple - an extra dependency and a line to require it at start of brunch-server.js 

Notes:

1. A .env file does not need to be present - everything will still work with standard environment variables (e.g. shell exports.)
2. Variables already set in the current environment will **not** be replaced by those with the same name found in the .env file.

